### PR TITLE
Add link to the source code

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,9 @@ Syntax: cpdfsqueeze <input file> [-upw <password>] [-opw <password>] <output fil
   -help  Display this list of options
   --help  Display this list of options
 ```
+
+The source code can be found at <https://github.com/johnwhitington/cpdfsqueeze>.
+
+```yaml
+SPDX-License-Identifier: LGPL-2.1-or-later
+```


### PR DESCRIPTION
This adds a link to the source code - and also adds a SPDX-Licence-Identifier (see https://spdx.github.io/spdx-spec/appendix-V-using-SPDX-short-identifiers-in-source-files/ for details)